### PR TITLE
fix: csp Error Unrecognized r'equire-trusted-types-for'

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,15 +2,28 @@ import withPlaiceholder from "@plaiceholder/next"
 
 /** @type {import('next').NextConfig} */
 
+const isDev = process.env.NODE_ENV === "development"
+const devHttp = isDev ? " http:" : ""
+const devWs = isDev ? " ws://localhost:3000" : ""
+
 const cspHeader = `
-    default-src 'self';
-    img-src 'self' https://*.s3.amazonaws.com data: blob:;
-    upgrade-insecure-requests;
+  default-src 'self' https:${devHttp};
+  connect-src 'self' https:${devHttp}${devWs};
+  img-src 'self' data: blob: https:${devHttp};
+  font-src 'self' data: https:${devHttp};
+  style-src 'self' 'unsafe-inline' https:${devHttp};
+  script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""};
 `
   .replace(/\n/g, "")
   .trim()
 
 const nextConfig = {
+  webpack: (config, { dev, isServer }) => {
+    if (dev && !isServer) {
+      config.devtool = "inline-source-map"
+    }
+    return config
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
### [작업 사항]

- csp 헤더 수정 (문제)
  - 이전에 설정한 헤더로 하면 default-src에 의존하던 다른 리소스(css, font 등)이 img-src 명시로 인해 동작이 제한됨
  - 그래서 css, font 로드가 안됐음... 해당 지시어들에 대해 'self'를 해도 캐러셀에서 외부 css를 받아 사용하기 때문에 이렇겐 사용이 안됨

- 해결
  - s3명시하던 거 빼고, 다른 지시어들도 설정 추가
  - require-trusted-types-for 지시어가 없는 헤더로 덮어씀
  - dev모드에서 자꾸 에러 발생하길래 조건부로 설정함

### [확인해야 할 사항]

- [x] 다 self로 설정했는데 dev, 프로덕션 둘 다 문제없이 잘 동작함. 왜? 버셀 배포 후에도 동작하는지 확인해야됨
