### PR TITLE
Fix mobile layout

### DIFF
--- a/src/app/(home)/hotArticleSection/styles.css
+++ b/src/app/(home)/hotArticleSection/styles.css
@@ -13,6 +13,15 @@
   align-items: center;
 }
 
+@media (max-width: 600px) {
+  .swiper-button-prev {
+    margin-left: -8px;
+  }
+  .swiper-button-next {
+    margin-right: -8px;
+  }
+}
+
 .swiper-button-next::after,
 .swiper-button-prev::after {
   color: white;

--- a/src/app/(home)/profileSection/mobile/MobileHeader.tsx
+++ b/src/app/(home)/profileSection/mobile/MobileHeader.tsx
@@ -45,7 +45,10 @@ export default function MobileHeader() {
           justifyContent: "space-between",
           alignItems: "center",
           width: "100%",
-          padding: "5px 32px",
+          padding: {
+            xs: "5px 8px",
+            sm: "5px 32px",
+          },
           maxWidth: 1200,
         }}
       >

--- a/src/app/(home)/tagSection/desktop/IndexSectionTag.tsx
+++ b/src/app/(home)/tagSection/desktop/IndexSectionTag.tsx
@@ -13,7 +13,10 @@ export default function IndexSectionTag({
   onClick,
 }: IndexSectionTagProps) {
   return (
-    <Button onClick={onClick} sx={{ minWidth: 0 }}>
+    <Button
+      onClick={onClick}
+      sx={{ minWidth: 0, "&:hover": { background: "none" } }}
+    >
       <CustomTypography
         size={15}
         color={isSelected ? "black" : "var(--gray)"}

--- a/src/app/components/common/BlurImage.tsx
+++ b/src/app/components/common/BlurImage.tsx
@@ -22,7 +22,6 @@ export default function BlurImage({
         position: "relative",
         width: "100%",
         paddingBottom: ratio,
-        background: "var(--primary)",
       }}
     >
       <Image


### PR DESCRIPTION
### [작업 사항]

- 캐러셀 네비게이션 마진
  - 마진을 각각 -8px씩 줘서 썸네일 이미지에 안붙게 조정
- 모바일 헤더 패딩
  - paddingY를 줄임
