### PR TITLE
Fix mobile layout

### DIFF
--- a/src/app/(home)/articleSection/ArticleThumbnail.tsx
+++ b/src/app/(home)/articleSection/ArticleThumbnail.tsx
@@ -19,42 +19,54 @@ export default function ArticleThumbnail({ article }: ArticleProps) {
     >
       <BlurImage src={article.thumbnail} blurDataURL={article.blurThumbnail} />
       <Box
-        padding={1}
-        paddingTop={3}
         sx={{
-          minHeight: { xs: 0, sm: "147px" },
+          minHeight: { xs: 0, sm: "138px" },
           display: "flex",
           flexDirection: "column",
+          paddingTop: { xs: 1.5, sm: 3 },
         }}
       >
         <CustomTypography
-          size={20}
           weight={700}
           sx={{
+            fontSize: {
+              xs: "16px",
+              sm: "20px",
+            },
             display: "-webkit-box",
             overflow: "hidden",
             WebkitBoxOrient: "vertical",
             WebkitLineClamp: 2,
             textOverflow: "ellipsis",
-            flex: 1,
           }}
         >
           {article.title}
         </CustomTypography>
         <CustomTypography
-          size={17}
           weight={500}
           color="var(--text-secondary)"
           sx={{
-            paddingTop: 1,
+            fontSize: {
+              xs: "13px",
+              sm: "17px",
+            },
             whiteSpace: "nowrap",
             overflow: "hidden",
             textOverflow: "ellipsis",
+            paddingTop: 1,
           }}
         >
           {article.description}
         </CustomTypography>
-        <CustomTypography size={14} color="gray">
+        <CustomTypography
+          color="gray"
+          sx={{
+            fontSize: {
+              xs: "12px",
+              sm: "14px",
+            },
+          }}
+        >
           {article.createdTime}
         </CustomTypography>
       </Box>

--- a/src/app/(home)/hotArticleSection/Carousel.tsx
+++ b/src/app/(home)/hotArticleSection/Carousel.tsx
@@ -73,16 +73,32 @@ export default function Carousel({ data }: CarouselProps) {
                   color="black"
                   weight={600}
                   sx={{
-                    fontSize: { xs: 18, sm: 20, md: 22, lg: 24 },
+                    fontSize: { xs: 16, sm: 20, md: 22, lg: 24 },
+                    display: "-webkit-box",
+                    overflow: "hidden",
+                    WebkitBoxOrient: "vertical",
+                    WebkitLineClamp: {
+                      xs: 1,
+                      sm: 2,
+                    },
+                    textOverflow: "ellipsis",
                   }}
                 >
                   {item.title}
                 </CustomTypography>
                 <CustomTypography
-                  sx={{
-                    fontSize: { xs: 13, sm: 14, md: 16, lg: 18 },
-                  }}
                   color="var(--gray)"
+                  sx={{
+                    fontSize: { xs: 12, sm: 14, md: 16, lg: 18 },
+                    display: "-webkit-box",
+                    overflow: "hidden",
+                    WebkitBoxOrient: "vertical",
+                    WebkitLineClamp: {
+                      xs: 1,
+                      sm: 2,
+                    },
+                    textOverflow: "ellipsis",
+                  }}
                 >
                   {item.description}
                 </CustomTypography>

--- a/src/app/(home)/hotArticleSection/HotArticle.tsx
+++ b/src/app/(home)/hotArticleSection/HotArticle.tsx
@@ -26,7 +26,7 @@ export default async function HotArticle() {
             borderRadius: 2,
             boxShadow:
               "inset 0px 2px 4px rgba(0, 0, 0, 0.5), 0px 2px 4px rgba(0, 0, 0, 0.3)",
-            margin: 4,
+            margin: { xs: 2, sm: 4 },
             background: "var(--primary-gradient)",
           }}
         >

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -14,7 +14,7 @@ export default async function Home() {
         flexGrow: 1,
         flexDirection: { xs: "column", md: "row" },
         paddingTop: {
-          xs: "56px",
+          xs: "40px",
           sm: "80px",
           md: "160px",
         },

--- a/src/app/(home)/profileSection/desktop/component/jukebox/Playlist.tsx
+++ b/src/app/(home)/profileSection/desktop/component/jukebox/Playlist.tsx
@@ -117,7 +117,6 @@ export default function Playlist({
                     sx={{
                       display: "flex",
                       width: "100%",
-                      justifyContent: "space-between",
                       textTransform: "none",
                       gap: 2,
                     }}
@@ -129,10 +128,30 @@ export default function Playlist({
                           ? "var(--primary)"
                           : "var(--text)"
                       }
+                      sx={{
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        width: "100%",
+                        textAlign: "left",
+                        fontSize: {
+                          xs: "0.75rem",
+                          sm: "1rem",
+                        },
+                      }}
                     >
                       {index}. {info.title} - {info.artist}
                     </CustomTypography>
-                    <CustomTypography>{info.time}</CustomTypography>
+                    <CustomTypography
+                      sx={{
+                        fontSize: {
+                          xs: "0.75rem",
+                          md: "1rem",
+                        },
+                      }}
+                    >
+                      {info.time}
+                    </CustomTypography>
                   </Button>
                 </Box>
               ))}

--- a/src/app/components/common/GradientBox.tsx
+++ b/src/app/components/common/GradientBox.tsx
@@ -40,7 +40,13 @@ export default function GradientBox({
           borderRadius: 100,
           boxShadow: "inset 1px 2px 6px rgba(0, 0, 0, 0.3)",
           background: backgroundColor,
-          padding: type === "button" ? "5px 20px" : "0px",
+          padding:
+            type === "button"
+              ? {
+                  xs: "5px 10px",
+                  sm: "5px 20px",
+                }
+              : "0px",
           "&:hover": {
             background:
               type === "button"


### PR DESCRIPTION
- 패딩, 폰트 크기 조절
  - 모바일 기준 보이는 요소의 크기를 조금씩 줄였읍니다
- playlist text overflow
  - 폰트 사이즈를 조절함
  - 지금은 넘치는 게 없는데 넘치는게 생기면 maxwidth 조절해서 textoverflow 갖다박은 거 동작하게 하면 됨

