### PR TITLE
refactor: 태그 필터링 데이터 구조 변경

### DIFF
--- a/src/app/(route)/(home)/articleSection/ArticlesList.tsx
+++ b/src/app/(route)/(home)/articleSection/ArticlesList.tsx
@@ -1,5 +1,5 @@
 import InfiniteScrollArticles from "./components/InfiniteScrollArticles"
-import getPaginatedData from "./lib/paginatedData"
+import { getPaginatedData } from "./lib/paginatedData"
 
 export default async function ArticlesList() {
   const paginatedData = await getPaginatedData()

--- a/src/app/(route)/(home)/articleSection/lib/paginatedData.ts
+++ b/src/app/(route)/(home)/articleSection/lib/paginatedData.ts
@@ -1,64 +1,74 @@
 import { getAllPost, getAllTagsWithCategory } from "@/lib/api/notion"
 import { PaginationData } from "@/types/article"
 import { NotionData } from "@/types/notion"
-import { CategoryTag } from "@/types/tags"
 
 const itemsPerPage = 4
 
 /**
- * 게시물 데이터를 tag, category별로 페이지네이션하여 저장
+ * id를 key로 가지는 postsById, categoryIndex, tagIndex를 반환합니다.
  */
-export default async function getPaginatedData() {
+export async function getPaginatedData() {
   const allPosts: NotionData[] = await getAllPost()
+
   const categoriesWithTags = await getAllTagsWithCategory()
 
+  const postsById: { [id: string]: NotionData } = {}
+  const categoryIndex: { [categoryName: string]: string[] } = {}
+  const tagIndex: { [tagName: string]: string[] } = {}
+
+  categoriesWithTags.forEach((category: any) => {
+    categoryIndex[category.name] = []
+    category.tags.forEach((tag: string) => {
+      tagIndex[tag] = []
+    })
+  })
+
+  allPosts.forEach((post) => {
+    const postId = post.id
+    postsById[postId] = post
+
+    if (categoryIndex[post.category]) {
+      categoryIndex[post.category].push(postId)
+    }
+
+    categoryIndex["전체보기"].push(postId)
+
+    post.tag.forEach((tag) => {
+      if (tagIndex[tag]) {
+        tagIndex[tag].push(postId)
+      }
+    })
+  })
+
   const paginatedData: PaginationData = {
-    category: {},
-    tag: {},
+    postsById,
+    categoryIndex,
+    tagIndex,
   }
 
-  categoriesWithTags.forEach((category: CategoryTag) => {
-    paginatedData.category[category.name] = []
-    category.tags.forEach((tag) => {
-      paginatedData.tag[tag] = []
-    })
-  })
-
-  // 게시물 데이터 추가
-  allPosts.forEach((post) => {
-    const overallPages = paginatedData.category["전체보기"]
-    const overallPageIndex = Math.floor(
-      overallPages.flat().length / itemsPerPage,
-    )
-    if (!overallPages[overallPageIndex]) {
-      overallPages[overallPageIndex] = []
-    }
-    overallPages[overallPageIndex].push(post)
-
-    // 카테고리별 게시물 추가
-    const categoryPages = paginatedData.category[post.category]
-    if (categoryPages) {
-      const categoryPageIndex = Math.floor(
-        categoryPages.flat().length / itemsPerPage,
-      )
-      if (!categoryPages[categoryPageIndex]) {
-        categoryPages[categoryPageIndex] = []
-      }
-      categoryPages[categoryPageIndex].push(post)
-    }
-
-    // 태그별 게시물 추가
-    post.tag.forEach((tagName) => {
-      const tagPages = paginatedData.tag[tagName]
-      if (tagPages) {
-        const tagPageIndex = Math.floor(tagPages.flat().length / itemsPerPage)
-        if (!tagPages[tagPageIndex]) {
-          tagPages[tagPageIndex] = []
-        }
-        tagPages[tagPageIndex].push(post)
-      }
-    })
-  })
-
   return paginatedData
+}
+
+export function getPostsByCategoryAndPage(
+  category: string,
+  pageNumber: number,
+  paginatedData: PaginationData,
+): NotionData[] {
+  const postIds = paginatedData.categoryIndex[category] || []
+  const startIndex = pageNumber * itemsPerPage
+  const endIndex = startIndex + itemsPerPage
+  const pagePostIds = postIds.slice(startIndex, endIndex)
+  return pagePostIds.map((id) => paginatedData.postsById[id])
+}
+
+export function getPostsByTagAndPage(
+  tag: string,
+  pageNumber: number,
+  paginatedData: PaginationData,
+): NotionData[] {
+  const postIds = paginatedData.tagIndex[tag] || []
+  const startIndex = pageNumber * itemsPerPage
+  const endIndex = startIndex + itemsPerPage
+  const pagePostIds = postIds.slice(startIndex, endIndex)
+  return pagePostIds.map((id) => paginatedData.postsById[id])
 }

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,4 +1,8 @@
 import {
+  getPostsByCategoryAndPage,
+  getPostsByTagAndPage,
+} from "@/app/(route)/(home)/articleSection/lib/paginatedData"
+import {
   articleListCurrentPageSelector,
   articleListHasMoreSelector,
   articleListSelector,
@@ -25,7 +29,11 @@ export default function useInfiniteScroll({
 
   useEffect(() => {
     if (!articleList.length) {
-      const articles = initialArticles[tag.type]?.[tag.tagName]?.[0] || []
+      const articles = getPostsByCategoryAndPage(
+        tag.tagName,
+        0,
+        initialArticles,
+      )
       setArticleList(articles)
     }
   }, [])
@@ -35,7 +43,10 @@ export default function useInfiniteScroll({
    */
   async function loadMoreArticles() {
     const next = page + 1
-    const articles = initialArticles[tag.type]?.[tag.tagName]?.[next] || []
+    const articles =
+      tag.type === "category"
+        ? getPostsByCategoryAndPage(tag.tagName, next, initialArticles)
+        : getPostsByTagAndPage(tag.tagName, next, initialArticles)
 
     if (articles?.length) {
       setPage(next)
@@ -55,7 +66,10 @@ export default function useInfiniteScroll({
    * Load articles based on the selected tag
    */
   async function loadTagArticles() {
-    const articles = initialArticles[tag.type]?.[tag.tagName]?.[0] || []
+    const articles =
+      tag.type === "category"
+        ? getPostsByCategoryAndPage(tag.tagName, 0, initialArticles)
+        : getPostsByTagAndPage(tag.tagName, 0, initialArticles)
     setArticleList(articles)
   }
 
@@ -73,7 +87,11 @@ export default function useInfiniteScroll({
   if (articleList.length) {
     returnArticleList = articleList
   } else if (tag.tagName === "전체보기") {
-    returnArticleList = initialArticles[tag.type]?.[tag.tagName]?.[0] || []
+    returnArticleList = getPostsByCategoryAndPage(
+      tag.tagName,
+      0,
+      initialArticles,
+    )
   }
 
   return {

--- a/src/lib/api/images.ts
+++ b/src/lib/api/images.ts
@@ -1,3 +1,5 @@
+"use server"
+
 import { NotionData } from "@/types/notion"
 import { S3, S3Client } from "@aws-sdk/client-s3"
 import { getPlaiceholder } from "plaiceholder"

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,5 +1,7 @@
 import { NotionData } from "./notion"
 
 export type PaginationData = {
-  [category: string]: { [tag: string]: NotionData[][] }
+  postsById: { [id: string]: NotionData }
+  categoryIndex: { [categoryName: string]: string[] }
+  tagIndex: { [tagName: string]: string[] }
 }


### PR DESCRIPTION
### [작업 사항]

- 기존: 데이터를 배열로 모두 저장(type: NotionData), 복수 태그일 경우 중복된 데이터 증가
- 변경 이유: 메모리가 너무 커질 거 같음
- 변경: 카테고리, 태그별 배열 구조는 유지하면서 id만 저장,
           postById를 추가해 id: notionData로 만듦.
           id로 찾을 수 있도록함

### [작업해야할 사항]

- [x] 게시글이 많을 때 유의미하게 줄었는지 확인하기
