### PR TITLE
fix: add www to base uri

### DIFF
--- a/src/app/(route)/articles/[slug]/page.tsx
+++ b/src/app/(route)/articles/[slug]/page.tsx
@@ -66,7 +66,7 @@ export async function generateMetadata({
       title: post?.title,
       description: post?.description,
       type: "website",
-      url: `https://obvoso.site/articles/${params.slug}`,
+      url: `https://www.obvoso.site/articles/${params.slug}`,
       images: [
         {
           url: post?.thumbnail!,
@@ -78,7 +78,7 @@ export async function generateMetadata({
       card: "summary_large_image",
       title: post?.title,
       description: post?.description,
-      images: [`https://obvoso.site/articles/${params.slug}`],
+      images: [`https://www.obvoso.site/articles/${params.slug}`],
     },
   }
   return metadata

--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -1,4 +1,4 @@
 User-Agent: *
 Allow: /
 
-Sitemap: https://obvoso.site/sitemap.xml
+Sitemap: https://www.obvoso.site/sitemap.xml

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -16,7 +16,7 @@ export default async function sitemap({
 }: {
   id: number
 }): Promise<MetadataRoute.Sitemap> {
-  const BASE_URL = "https://obvoso.site"
+  const BASE_URL = "https://www.obvoso.site"
 
   const articles = await getAllPost()
   const url = articles.map((article) => ({


### PR DESCRIPTION
### [작업 사항]

- BASE URI에 www 추가
  - https://obvoso.site -> https://www.obvoso.site
  - 기본적으로 www가 붙은 url로 리다이렉션됨
  - 검색 엔진에서 www 유무에 따라 서로 다른 도메인으로 인식된다고 함
  - 게시글 제목으로 검색시 개별 게시글이 아닌 블로그 홈만 자꾸 검색됨..