### PR TITLE
[FIX] preload route handler 분리 후 호출

### DIFF
--- a/src/app/api/preload/route.ts
+++ b/src/app/api/preload/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+
+export async function GET() {
+  const pageUrl = "https://www.obvoso.site"
+
+  try {
+    console.log(`Preloading page`)
+    const response = await fetch(pageUrl, { method: "GET", cache: "no-cache" })
+    console.log(`Fetch response status: ${response.status}`)
+    return NextResponse.json({ success: true, status: response.status })
+  } catch (error) {
+    console.error("Preload failed:", error)
+    return NextResponse.json({ success: false, error })
+  }
+}

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -11,12 +11,12 @@ export async function PATCH(request: NextRequest) {
     revalidateTag("posts")
     revalidatePath("/", "page")
 
-    const pageUrl = `https://www.obvoso.site`
-    setTimeout(() => {
-      fetch(pageUrl, { method: "GET", cache: "no-cache" })
-        .then(() => console.log(`Successfully fetched ${pageUrl}`))
-        .catch((err) => console.error(`Failed to fetch ${pageUrl}`, err))
-    }, 1000)
+    try {
+      await fetch("https://www.obvoso.site/api/preload", { method: "GET" })
+    } catch (error) {
+      console.error(`Preload API call failed:`, error)
+    }
+
     return Response.json({ revalidated: true, message: id, now: new Date() })
   }
   return Response.json({ revalidated: false, message: id, now: new Date() })


### PR DESCRIPTION
### [작업 사항]

- /api/preload
  - fetch 함수를 해당 api로 분리
  - /api/revalidate에서 /api/preload호출

