### PR TITLE
[FIX] 서치파람으로 받은 slug를 다시 encoding

### DIFF
--- a/src/app/api/preload/route.ts
+++ b/src/app/api/preload/route.ts
@@ -4,15 +4,17 @@ export async function GET(request: NextRequest) {
   const pageUrl = "https://www.obvoso.site"
   const { searchParams } = new URL(request.url)
   const slug = searchParams.get("slug")
+  const encodedSlug = encodeURIComponent(slug || "")
 
   try {
     console.log(`Preloading page`)
     console.log(`Page URL: ${slug}`)
+    console.log(`Encoded URL: ${encodedSlug}`)
     const rootResponse = await fetch(pageUrl, {
       method: "GET",
       cache: "no-cache",
     })
-    const pageResponse = await fetch(`${pageUrl}/articles/${slug}`, {
+    const pageResponse = await fetch(`${pageUrl}/articles/${encodedSlug}`, {
       method: "GET",
       cache: "no-cache",
     })


### PR DESCRIPTION
### [작업 사항]

- encodeURIComponent로 인코딩을 해서 보내도, searchParams로 받을 때 decode가 된 값이 나옵니다.
  - 받은 후 다시 인코딩을 수행합니다

### [작업해야할 사항]

- [ ] 진짜로 되는지 확인..
