### PR TITLE
[FIX] promise.All로 루트, 페이지 fetch를 병렬 요청

### DIFF
--- a/src/app/api/preload/route.ts
+++ b/src/app/api/preload/route.ts
@@ -11,19 +11,22 @@ export async function GET(request: NextRequest) {
     console.log(`Preloading page`)
     console.log(`Page URL: ${slug}`)
     console.log(`Encoded URL: ${encodedSlug}`)
-    const rootResponse = await fetch(pageUrl, {
-      method: "GET",
-      cache: "no-cache",
-    })
-    const pageResponse = await fetch(`${pageUrl}/articles/${encodedSlug}`, {
-      method: "GET",
-      cache: "no-cache",
-    })
+
+    const [rootResponse, pageResponse] = await Promise.all([
+      fetch(pageUrl, { method: "GET", cache: "no-cache" }),
+      fetch(`${pageUrl}/articles/${encodedSlug}`, {
+        method: "GET",
+        cache: "no-cache",
+      }),
+    ])
+
     console.log(`Fetch root response status: ${rootResponse.status}`)
     console.log(`Fetch page response status: ${pageResponse.status}`)
+
     return NextResponse.json({
       success: true,
-      status: rootResponse.status && pageResponse.status,
+      rootStatus: rootResponse.status,
+      pageStatus: pageResponse.status,
     })
   } catch (error) {
     console.error("Preload failed:", error)


### PR DESCRIPTION
### [작업 사항]

서버리스라 그런지(불명확) 2개의 요청이 모두 전송되지 않아 promise.All로 병렬 요청하도록 변경
첫번째 fetch만 실행되고, 두번째 fetch는 실행되지 않고 종료되었습니다.
